### PR TITLE
14 on deck list page add a sort by option

### DIFF
--- a/client/src/components/decks/DeckList.tsx
+++ b/client/src/components/decks/DeckList.tsx
@@ -1,4 +1,4 @@
-import {  useState } from "react";
+import { useMemo, useState } from "react";
 import { DropdownMenu, DropdownMenuCheckboxItem, DropdownMenuContent, DropdownMenuTrigger } from "@/components/ui/dropdown-menu";
 
 import MagicCardImage from "../cards/MagicCardImage";
@@ -30,8 +30,16 @@ export default function DeckList({ deck }: DeckListProps) {
   const [groupBy, setGroupBy] = useState<"type" | "cmc">("type");
   const [sortBy, setSortBy] = useState<"name" | "cmc">("cmc");
 
-
-  if (sortBy === "cmc") deck.sort((a, b) => a.card.cmc - b.card.cmc);
+  const sortedDeck = useMemo(() => {
+    const copy = [...deck];
+    const safeCmc = (n: number | null | undefined) => (Number.isFinite(n as number) ? (n as number) : Number.POSITIVE_INFINITY);
+    return copy.sort((a, b) => {
+      if (sortBy === "name") return a.card.cardName.localeCompare(b.card.cardName);
+      // sortBy === "cmc"
+      const diff = safeCmc(a.card.cmc) - safeCmc(b.card.cmc);
+      return diff !== 0 ? diff : a.card.cardName.localeCompare(b.card.cardName);
+    });
+  }, [deck, sortBy]);
 
   const commander: DeckCardDetails[] = [];
   const creatures: DeckCardDetails[] = [];
@@ -43,39 +51,39 @@ export default function DeckList({ deck }: DeckListProps) {
   const planeswalkers: DeckCardDetails[] = [];
   const lands: DeckCardDetails[] = [];
 
-  for (let i = 0; i < deck!.length; i++) {
-    if (deck[i].commander) {
-      commander.push(deck[i]);
+  for (let i = 0; i < sortedDeck!.length; i++) {
+    if (sortedDeck[i].commander) {
+      commander.push(sortedDeck[i]);
       continue;
     }
 
-    switch (deck[i].card.cardType) {
+    switch (sortedDeck[i].card.cardType) {
       case "creature":
-        creatures.push(deck[i]);
+        creatures.push(sortedDeck[i]);
         break;
       case "instant":
-        instants.push(deck[i]);
+        instants.push(sortedDeck[i]);
         break;
       case "sorcery":
-        sorceries.push(deck[i]);
+        sorceries.push(sortedDeck[i]);
         break;
       case "artifact":
-        artifacts.push(deck[i]);
+        artifacts.push(sortedDeck[i]);
         break;
       case "enchantment":
-        enchantments.push(deck[i]);
+        enchantments.push(sortedDeck[i]);
         break;
       case "battle":
-        battles.push(deck[i]);
+        battles.push(sortedDeck[i]);
         break;
       case "planeswalker":
-        planeswalkers.push(deck[i]);
+        planeswalkers.push(sortedDeck[i]);
         break;
       case "land":
-        lands.push(deck[i]);
+        lands.push(sortedDeck[i]);
         break;
       default:
-        throw new Error(`${deck[i].card.cardName} has an unknown card type`);
+        throw new Error(`${sortedDeck[i].card.cardName} has an unknown card type`);
     }
   }
 
@@ -93,19 +101,19 @@ export default function DeckList({ deck }: DeckListProps) {
   };
 
   const cardsByMana = {
-    Commander: deck.filter((card) => card.commander),
-    "0 ": deck.filter((card) => card.card.cmc === 0 && card.card.cardType !== "land"),
-    "1 ": deck.filter((card) => card.card.cmc === 1 && !card.commander),
-    "2 ": deck.filter((card) => card.card.cmc === 2 && !card.commander),
-    "3 ": deck.filter((card) => card.card.cmc === 3 && !card.commander),
-    "4 ": deck.filter((card) => card.card.cmc === 4 && !card.commander),
-    "5 ": deck.filter((card) => card.card.cmc === 5 && !card.commander),
-    "6 ": deck.filter((card) => card.card.cmc === 6 && !card.commander),
-    "7 ": deck.filter((card) => card.card.cmc === 7 && !card.commander),
-    "8 ": deck.filter((card) => card.card.cmc === 8 && !card.commander),
-    "9 ": deck.filter((card) => card.card.cmc === 9 && !card.commander),
-    "10+": deck.filter((card) => card.card.cmc >= 10),
-    Lands: deck.filter((card) => card.card.cardType === "land"),
+    Commander: sortedDeck.filter((card) => card.commander),
+    "0 ": sortedDeck.filter((card) => card.card.cmc === 0 && card.card.cardType !== "land" && !card.commander),
+    "1 ": sortedDeck.filter((card) => card.card.cmc === 1 && !card.commander),
+    "2 ": sortedDeck.filter((card) => card.card.cmc === 2 && !card.commander),
+    "3 ": sortedDeck.filter((card) => card.card.cmc === 3 && !card.commander),
+    "4 ": sortedDeck.filter((card) => card.card.cmc === 4 && !card.commander),
+    "5 ": sortedDeck.filter((card) => card.card.cmc === 5 && !card.commander),
+    "6 ": sortedDeck.filter((card) => card.card.cmc === 6 && !card.commander),
+    "7 ": sortedDeck.filter((card) => card.card.cmc === 7 && !card.commander),
+    "8 ": sortedDeck.filter((card) => card.card.cmc === 8 && !card.commander),
+    "9 ": sortedDeck.filter((card) => card.card.cmc === 9 && !card.commander),
+    "10+": sortedDeck.filter((card) => card.card.cmc >= 10 && !card.commander),
+    Lands: sortedDeck.filter((card) => card.card.cardType === "land"),
   };
 
   async function downloadDeckListHandler(copyTo: "file" | "clipboard") {
@@ -124,26 +132,22 @@ export default function DeckList({ deck }: DeckListProps) {
     const url = window.URL.createObjectURL(new Blob([res as string]));
     const link = document.createElement("a");
     link.href = url;
-    link.setAttribute("download", `${deck[0].deck.deckName}.txt`);
+    link.setAttribute("download", `${sortedDeck[0].deck.deckName}.txt`);
     document.body.appendChild(link);
     link.click();
     link.remove();
   }
 
-  function sortDeckBy(sortBy: "name" | "cmc") {
-    setSortBy(sortBy);
-
-    if (sortBy === "name") deck.sort((a,b) => a.card.cardName.localeCompare(b.card.cardName));
-    if (sortBy === "cmc") deck.sort((a, b) => a.card.cmc - b.card.cmc);
+  function sortDeckBy(next: "name" | "cmc") {
+    setSortBy(next);
   }
 
   return (
     <div>
       <div className="mx-auto text-center mb-10 flex justify-center items-center gap-2">
-
         {/* Group By Select */}
         <h1>Group By</h1>
-        <Select defaultValue={groupBy} onValueChange={(value: "type" | "cmc") => setGroupBy(value)}>
+        <Select value={groupBy} onValueChange={(value: "type" | "cmc") => setGroupBy(value)}>
           <SelectTrigger className="w-[180px]">
             <SelectValue />
           </SelectTrigger>
@@ -157,7 +161,7 @@ export default function DeckList({ deck }: DeckListProps) {
 
         {/* Sortby Select */}
         <h1>Sort By</h1>
-        <Select defaultValue={sortBy} onValueChange={(value: "name" | "cmc") => sortDeckBy(value)}>
+        <Select value={sortBy} onValueChange={(value: "name" | "cmc") => sortDeckBy(value)}>
           <SelectTrigger className="w-[180px]">
             <SelectValue />
           </SelectTrigger>
@@ -168,8 +172,6 @@ export default function DeckList({ deck }: DeckListProps) {
             </SelectGroup>
           </SelectContent>
         </Select>
-
-
       </div>
       <div className="grid md:grid-cols-[2fr_5fr_1fr] justify-center">
         <div className="md:col-span-1 mx-auto flex flex-col">

--- a/client/src/components/decks/DeckList.tsx
+++ b/client/src/components/decks/DeckList.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { DropdownMenu, DropdownMenuCheckboxItem, DropdownMenuContent, DropdownMenuTrigger } from "@/components/ui/dropdown-menu";
 
 import MagicCardImage from "../cards/MagicCardImage";
@@ -26,10 +26,13 @@ export default function DeckList({ deck }: DeckListProps) {
   );
   const { populateLands } = usePopulateBasicLands();
 
-  // State for grouping
+  // State for grouping/sorting
   const [groupBy, setGroupBy] = useState<"type" | "cmc">("type");
+  const [sortBy, setSortBy] = useState<"name" | "cmc">("cmc");
 
-  deck?.sort((a, b) => a.card.cmc - b.card.cmc).sort((a,b) => a.card.cardName.localeCompare(b.card.cardName)); // sort the cards by cmc
+
+  if (sortBy === "cmc") deck.sort((a, b) => a.card.cmc - b.card.cmc);
+
   const commander: DeckCardDetails[] = [];
   const creatures: DeckCardDetails[] = [];
   const instants: DeckCardDetails[] = [];
@@ -91,16 +94,16 @@ export default function DeckList({ deck }: DeckListProps) {
 
   const cardsByMana = {
     Commander: deck.filter((card) => card.commander),
-    "0": deck.filter((card) => card.card.cmc === 0 && card.card.cardType !== "land"),
-    "1": deck.filter((card) => card.card.cmc === 1 && !card.commander),
-    "2": deck.filter((card) => card.card.cmc === 2 && !card.commander),
-    "3": deck.filter((card) => card.card.cmc === 3 && !card.commander),
-    "4": deck.filter((card) => card.card.cmc === 4 && !card.commander),
-    "5": deck.filter((card) => card.card.cmc === 5 && !card.commander),
-    "6": deck.filter((card) => card.card.cmc === 6 && !card.commander),
-    "7": deck.filter((card) => card.card.cmc === 7 && !card.commander),
-    "8": deck.filter((card) => card.card.cmc === 8 && !card.commander),
-    "9": deck.filter((card) => card.card.cmc === 9 && !card.commander),
+    "0 ": deck.filter((card) => card.card.cmc === 0 && card.card.cardType !== "land"),
+    "1 ": deck.filter((card) => card.card.cmc === 1 && !card.commander),
+    "2 ": deck.filter((card) => card.card.cmc === 2 && !card.commander),
+    "3 ": deck.filter((card) => card.card.cmc === 3 && !card.commander),
+    "4 ": deck.filter((card) => card.card.cmc === 4 && !card.commander),
+    "5 ": deck.filter((card) => card.card.cmc === 5 && !card.commander),
+    "6 ": deck.filter((card) => card.card.cmc === 6 && !card.commander),
+    "7 ": deck.filter((card) => card.card.cmc === 7 && !card.commander),
+    "8 ": deck.filter((card) => card.card.cmc === 8 && !card.commander),
+    "9 ": deck.filter((card) => card.card.cmc === 9 && !card.commander),
     "10+": deck.filter((card) => card.card.cmc >= 10),
     Lands: deck.filter((card) => card.card.cardType === "land"),
   };
@@ -127,11 +130,19 @@ export default function DeckList({ deck }: DeckListProps) {
     link.remove();
   }
 
+  function sortDeckBy(sortBy: "name" | "cmc") {
+    setSortBy(sortBy);
+
+    if (sortBy === "name") deck.sort((a,b) => a.card.cardName.localeCompare(b.card.cardName));
+    if (sortBy === "cmc") deck.sort((a, b) => a.card.cmc - b.card.cmc);
+  }
+
   return (
     <div>
       <div className="mx-auto text-center my-10 flex justify-center items-center gap-2">
-        <h1>Group By</h1>
 
+        {/* Group By Select */}
+        <h1>Group By</h1>
         <Select defaultValue={groupBy} onValueChange={(value: "type" | "cmc") => setGroupBy(value)}>
           <SelectTrigger className="w-[180px]">
             <SelectValue />
@@ -143,6 +154,22 @@ export default function DeckList({ deck }: DeckListProps) {
             </SelectGroup>
           </SelectContent>
         </Select>
+
+        {/* Sortby Select */}
+        <h1>Sort By</h1>
+        <Select defaultValue={sortBy} onValueChange={(value: "name" | "cmc") => sortDeckBy(value)}>
+          <SelectTrigger className="w-[180px]">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectGroup>
+              <SelectItem value="cmc">CMC</SelectItem>
+              <SelectItem value="name">Name</SelectItem>
+            </SelectGroup>
+          </SelectContent>
+        </Select>
+
+
       </div>
       <div className="grid md:grid-cols-[2fr_5fr_1fr] justify-center">
         <div className="md:col-span-1 mx-auto flex flex-col">

--- a/client/src/components/decks/DeckList.tsx
+++ b/client/src/components/decks/DeckList.tsx
@@ -10,6 +10,7 @@ import { usePopulateBasicLands } from "./useDeckQuery";
 import { useParams } from "react-router-dom";
 import { useUser } from "../user/useUser";
 import toast from "react-hot-toast";
+import { Select, SelectContent, SelectGroup, SelectItem, SelectTrigger, SelectValue } from "../ui/select";
 
 interface DeckListProps {
   deck: DeckCardDetails[];
@@ -25,7 +26,10 @@ export default function DeckList({ deck }: DeckListProps) {
   );
   const { populateLands } = usePopulateBasicLands();
 
-  deck?.sort((a, b) => a.card.cmc - b.card.cmc); // sort the cards by cmc
+  // State for grouping
+  const [groupBy, setGroupBy] = useState<"type" | "cmc">("type");
+
+  deck?.sort((a, b) => a.card.cmc - b.card.cmc).sort((a,b) => a.card.cardName.localeCompare(b.card.cardName)); // sort the cards by cmc
   const commander: DeckCardDetails[] = [];
   const creatures: DeckCardDetails[] = [];
   const instants: DeckCardDetails[] = [];
@@ -85,6 +89,22 @@ export default function DeckList({ deck }: DeckListProps) {
     Lands: lands,
   };
 
+  const cardsByMana = {
+    Commander: deck.filter((card) => card.commander),
+    "0": deck.filter((card) => card.card.cmc === 0 && card.card.cardType !== "land"),
+    "1": deck.filter((card) => card.card.cmc === 1 && !card.commander),
+    "2": deck.filter((card) => card.card.cmc === 2 && !card.commander),
+    "3": deck.filter((card) => card.card.cmc === 3 && !card.commander),
+    "4": deck.filter((card) => card.card.cmc === 4 && !card.commander),
+    "5": deck.filter((card) => card.card.cmc === 5 && !card.commander),
+    "6": deck.filter((card) => card.card.cmc === 6 && !card.commander),
+    "7": deck.filter((card) => card.card.cmc === 7 && !card.commander),
+    "8": deck.filter((card) => card.card.cmc === 8 && !card.commander),
+    "9": deck.filter((card) => card.card.cmc === 9 && !card.commander),
+    "10+": deck.filter((card) => card.card.cmc >= 10),
+    Lands: deck.filter((card) => card.card.cardType === "land"),
+  };
+
   async function downloadDeckListHandler(copyTo: "file" | "clipboard") {
     const res = await deckApi.downloadDeckList(Number(deckId), idToken);
 
@@ -108,7 +128,22 @@ export default function DeckList({ deck }: DeckListProps) {
   }
 
   return (
-    <>
+    <div>
+      <div className="mx-auto text-center my-10 flex justify-center items-center gap-2">
+        <h1>Group By</h1>
+
+        <Select defaultValue={groupBy} onValueChange={(value: "type" | "cmc") => setGroupBy(value)}>
+          <SelectTrigger className="w-[180px]">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectGroup>
+              <SelectItem value="type">Type</SelectItem>
+              <SelectItem value="cmc">CMC</SelectItem>
+            </SelectGroup>
+          </SelectContent>
+        </Select>
+      </div>
       <div className="grid md:grid-cols-[2fr_5fr_1fr] justify-center">
         <div className="md:col-span-1 mx-auto flex flex-col">
           <div className="sticky top-20 flex flex-col">
@@ -131,13 +166,13 @@ export default function DeckList({ deck }: DeckListProps) {
         </div>
         <div className="w-full rounded-md bg-slate-200/30 px-3 sm:columns-1 md:columns-1 lg:columns-2">
           {/* Iterate through each car type then each card in that type */}
-          {Object.entries(CardTypes).map(([heading, cards]) => {
+          {Object.entries(groupBy === "cmc" ? cardsByMana : CardTypes).map(([heading, cards]) => {
             return cards.length > 0 ? (
               <CardTypeContainer key={heading} cards={cards} heading={heading} hoverFunc={setShownCardImgUIrl} />
             ) : null;
           })}
         </div>
       </div>
-    </>
+    </div>
   );
 }

--- a/client/src/components/decks/DeckList.tsx
+++ b/client/src/components/decks/DeckList.tsx
@@ -100,21 +100,24 @@ export default function DeckList({ deck }: DeckListProps) {
     Lands: lands,
   };
 
-  const cardsByMana = {
-    Commander: sortedDeck.filter((card) => card.commander),
-    "0 ": sortedDeck.filter((card) => card.card.cmc === 0 && card.card.cardType !== "land" && !card.commander),
-    "1 ": sortedDeck.filter((card) => card.card.cmc === 1 && !card.commander),
-    "2 ": sortedDeck.filter((card) => card.card.cmc === 2 && !card.commander),
-    "3 ": sortedDeck.filter((card) => card.card.cmc === 3 && !card.commander),
-    "4 ": sortedDeck.filter((card) => card.card.cmc === 4 && !card.commander),
-    "5 ": sortedDeck.filter((card) => card.card.cmc === 5 && !card.commander),
-    "6 ": sortedDeck.filter((card) => card.card.cmc === 6 && !card.commander),
-    "7 ": sortedDeck.filter((card) => card.card.cmc === 7 && !card.commander),
-    "8 ": sortedDeck.filter((card) => card.card.cmc === 8 && !card.commander),
-    "9 ": sortedDeck.filter((card) => card.card.cmc === 9 && !card.commander),
-    "10+": sortedDeck.filter((card) => (card.card.cmc ?? Number.POSITIVE_INFINITY) >= 10 && !card.commander),
-    Lands: sortedDeck.filter((card) => card.card.cardType === "land"),
-  };
+  const cardsByMana = useMemo(
+    () => ({
+      Commander: sortedDeck.filter((card) => card.commander),
+      "0 ": sortedDeck.filter((card) => card.card.cmc === 0 && card.card.cardType !== "land" && !card.commander),
+      "1 ": sortedDeck.filter((card) => card.card.cmc === 1 && !card.commander),
+      "2 ": sortedDeck.filter((card) => card.card.cmc === 2 && !card.commander),
+      "3 ": sortedDeck.filter((card) => card.card.cmc === 3 && !card.commander),
+      "4 ": sortedDeck.filter((card) => card.card.cmc === 4 && !card.commander),
+      "5 ": sortedDeck.filter((card) => card.card.cmc === 5 && !card.commander),
+      "6 ": sortedDeck.filter((card) => card.card.cmc === 6 && !card.commander),
+      "7 ": sortedDeck.filter((card) => card.card.cmc === 7 && !card.commander),
+      "8 ": sortedDeck.filter((card) => card.card.cmc === 8 && !card.commander),
+      "9 ": sortedDeck.filter((card) => card.card.cmc === 9 && !card.commander),
+      "10+": sortedDeck.filter((card) => (card.card.cmc ?? Number.POSITIVE_INFINITY) >= 10 && !card.commander),
+      Lands: sortedDeck.filter((card) => card.card.cardType === "land"),
+    }),
+    [sortedDeck]
+  );
 
   async function downloadDeckListHandler(copyTo: "file" | "clipboard") {
     const res = await deckApi.downloadDeckList(Number(deckId), idToken);
@@ -146,7 +149,7 @@ export default function DeckList({ deck }: DeckListProps) {
     <div>
       <div className="mx-auto text-center mb-10 flex justify-center items-center gap-2">
         {/* Group By Select */}
-        <label htmlFor="group-by-select">Group By</label>
+        <label>Group By</label>
         <Select value={groupBy} onValueChange={(value: "type" | "cmc") => setGroupBy(value)}>
           <SelectTrigger className="w-[180px]">
             <SelectValue />
@@ -160,7 +163,7 @@ export default function DeckList({ deck }: DeckListProps) {
         </Select>
 
         {/* Sortby Select */}
-        <label htmlFor="sort-by-select">Sort By</label>
+        <label>Sort By</label>
         <Select value={sortBy} onValueChange={(value: "name" | "cmc") => sortDeckBy(value)}>
           <SelectTrigger className="w-[180px]">
             <SelectValue />

--- a/client/src/components/decks/DeckList.tsx
+++ b/client/src/components/decks/DeckList.tsx
@@ -139,7 +139,7 @@ export default function DeckList({ deck }: DeckListProps) {
 
   return (
     <div>
-      <div className="mx-auto text-center my-10 flex justify-center items-center gap-2">
+      <div className="mx-auto text-center mb-10 flex justify-center items-center gap-2">
 
         {/* Group By Select */}
         <h1>Group By</h1>

--- a/client/src/components/decks/DeckList.tsx
+++ b/client/src/components/decks/DeckList.tsx
@@ -112,7 +112,7 @@ export default function DeckList({ deck }: DeckListProps) {
     "7 ": sortedDeck.filter((card) => card.card.cmc === 7 && !card.commander),
     "8 ": sortedDeck.filter((card) => card.card.cmc === 8 && !card.commander),
     "9 ": sortedDeck.filter((card) => card.card.cmc === 9 && !card.commander),
-    "10+": sortedDeck.filter((card) => card.card.cmc >= 10 && !card.commander),
+    "10+": sortedDeck.filter((card) => (card.card.cmc ?? Number.POSITIVE_INFINITY) >= 10 && !card.commander),
     Lands: sortedDeck.filter((card) => card.card.cardType === "land"),
   };
 
@@ -146,7 +146,7 @@ export default function DeckList({ deck }: DeckListProps) {
     <div>
       <div className="mx-auto text-center mb-10 flex justify-center items-center gap-2">
         {/* Group By Select */}
-        <h1>Group By</h1>
+        <label htmlFor="group-by-select">Group By</label>
         <Select value={groupBy} onValueChange={(value: "type" | "cmc") => setGroupBy(value)}>
           <SelectTrigger className="w-[180px]">
             <SelectValue />
@@ -160,7 +160,7 @@ export default function DeckList({ deck }: DeckListProps) {
         </Select>
 
         {/* Sortby Select */}
-        <h1>Sort By</h1>
+        <label htmlFor="sort-by-select">Sort By</label>
         <Select value={sortBy} onValueChange={(value: "name" | "cmc") => sortDeckBy(value)}>
           <SelectTrigger className="w-[180px]">
             <SelectValue />

--- a/client/src/components/decks/DeckList.tsx
+++ b/client/src/components/decks/DeckList.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import {  useState } from "react";
 import { DropdownMenu, DropdownMenuCheckboxItem, DropdownMenuContent, DropdownMenuTrigger } from "@/components/ui/dropdown-menu";
 
 import MagicCardImage from "../cards/MagicCardImage";

--- a/client/src/pages/DeckDetails.tsx
+++ b/client/src/pages/DeckDetails.tsx
@@ -82,11 +82,12 @@ export default function DeckDetails() {
 
   if (isWaitingForDeck) return <Loader />;
   if (deckByIdError) return <ErrorMessage msg={`There was an error loading deck with deckId: ${deckId}`} />;
+  if (!deckById || deckById.length == 0) return <ErrorMessage msg="There was and error fetching the deck" />
 
-  const deckName = deckById![0].deck.deckName;
-  const deckTheme = deckById![0].deck.theme;
-  const commanderName = deckById![0].deck.commander;
-  const deckColorIdentity = deckById![0].deck.colorIdentity;
+  const deckName = deckById[0].deck.deckName;
+  const deckTheme = deckById[0].deck.theme;
+  const commanderName = deckById[0].deck.commander;
+  const deckColorIdentity = deckById[0].deck.colorIdentity;
 
   function addCardToDeckHandler() {
     if (!cardToSearch) return;

--- a/client/src/pages/DeckDetails.tsx
+++ b/client/src/pages/DeckDetails.tsx
@@ -240,7 +240,7 @@ export default function DeckDetails() {
             <TabsTrigger value="landCycles">Land Cycles</TabsTrigger>
           </TabsList>
           <TabsContent value="deckList">
-            <div className="flex justify-center items-center flex-col mb-10 px-5">
+            <div className="flex justify-center items-center flex-col px-5">
               <div className="flex items-center gap-2">
                 <CardSearchWithAutoComplete label="Search Card" setValue={setCardToSearch} />
                 <FaEye onClick={toggleCardInfoOverlayHandler} />

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,8 +6,6 @@ services:
     restart: always
     volumes:
       - postgresdata:/var/lib/postgresql/data
-    ports:
-      - "5432:5432"
     environment:
       POSTGRES_USER: stoffel
       POSTGRES_PASSWORD: stoffel

--- a/server/src/main/java/com/mtg_app/dao/MagicCardRepository.java
+++ b/server/src/main/java/com/mtg_app/dao/MagicCardRepository.java
@@ -11,7 +11,7 @@ import com.mtg_app.entity.MagicCard;
 public interface MagicCardRepository extends JpaRepository<MagicCard, Integer> {
     // basic crud operations extends from the JPA repository
 
-    @Query("FROM MagicCard c WHERE c.cardName = :cardName")
+    @Query(value="SELECT * FROM magic_card c WHERE c.card_name = :cardName LIMIT 1", nativeQuery = true)
     MagicCard getCardByName(@Param("cardName") String cardName);
 
     @Query("SELECT c.cardName FROM MagicCard c WHERE c.cardName IN :cards")

--- a/server/src/main/java/com/mtg_app/service/MagicDeckCardService.java
+++ b/server/src/main/java/com/mtg_app/service/MagicDeckCardService.java
@@ -119,7 +119,6 @@ public class MagicDeckCardService implements MagicDeckCardServiceInterface {
                     this.createOrUpdateDeckCardMapping(alreadyInDeck.get().getCard(), deck, false, entry.getValue());
                 } else {
                     MagicCard card = this.magicCardRepository.getCardByName(entry.getKey());
-                    System.out.println("Already in deck " + card);
                     this.createOrUpdateDeckCardMapping(card, deck, false, entry.getValue());
                 }
             }

--- a/server/src/main/java/com/mtg_app/service/MagicDeckCardService.java
+++ b/server/src/main/java/com/mtg_app/service/MagicDeckCardService.java
@@ -63,7 +63,7 @@ public class MagicDeckCardService implements MagicDeckCardServiceInterface {
     @Override
     public void updateCardQuantity(int deckId, int cardId, int quantity) {
         this.magicDeckCardRepository.updateCardQuantityByDeckIdAndCardId(deckId, cardId, quantity);
-    } 
+    }
 
     @Override
     public void removeCardFromDeck(int deckId, int cardId) {
@@ -119,6 +119,7 @@ public class MagicDeckCardService implements MagicDeckCardServiceInterface {
                     this.createOrUpdateDeckCardMapping(alreadyInDeck.get().getCard(), deck, false, entry.getValue());
                 } else {
                     MagicCard card = this.magicCardRepository.getCardByName(entry.getKey());
+                    System.out.println("Already in deck " + card);
                     this.createOrUpdateDeckCardMapping(card, deck, false, entry.getValue());
                 }
             }

--- a/server/src/main/java/com/mtg_app/service/MagicDeckService.java
+++ b/server/src/main/java/com/mtg_app/service/MagicDeckService.java
@@ -28,7 +28,8 @@ public class MagicDeckService implements MagicDeckServiceInterface {
     private final MagicDeckCardTokenService magicDeckCardTokenService;
 
     @Autowired
-    public MagicDeckService(MagicDeckRepository magicDeckRepository, MagicDeckCardService magicDeckCardService, MagicCardService magicCardService, MagicDeckCardTokenService magicDeckCardTokenService) {
+    public MagicDeckService(MagicDeckRepository magicDeckRepository, MagicDeckCardService magicDeckCardService,
+            MagicCardService magicCardService, MagicDeckCardTokenService magicDeckCardTokenService) {
         this.magicDeckRepository = magicDeckRepository;
         this.magicDeckCardService = magicDeckCardService;
         this.magicCardService = magicCardService;
@@ -91,18 +92,24 @@ public class MagicDeckService implements MagicDeckServiceInterface {
     }
 
     /**
-     * Adds a card to the specified Magic deck, including handling any associated token cards.
+     * Adds a card to the specified Magic deck, including handling any associated
+     * token cards.
      *
-     * <p>This method performs the following actions:
+     * <p>
+     * This method performs the following actions:
      * <ul>
-     *   <li>Retrieves or creates a new {@link MagicCard} based on the provided {@link MagicCardRequest}.</li>
-     *   <li>Adds the card to the deck using the deck-card mapping service.</li>
-     *   <li>If the card has associated token parts (as indicated by {@code getAll_parts()}), 
-     *       it identifies all tokens and creates deck-card-token mappings for each token.</li>
+     * <li>Retrieves or creates a new {@link MagicCard} based on the provided
+     * {@link MagicCardRequest}.</li>
+     * <li>Adds the card to the deck using the deck-card mapping service.</li>
+     * <li>If the card has associated token parts (as indicated by
+     * {@code getAll_parts()}),
+     * it identifies all tokens and creates deck-card-token mappings for each
+     * token.</li>
      * </ul>
      *
      * @param deck the {@link MagicDeck} to which the card will be added
-     * @param card the {@link MagicCardRequest} containing card details and possible token parts
+     * @param card the {@link MagicCardRequest} containing card details and possible
+     *             token parts
      */
     @Override
     public void addCardToDeck(MagicDeck deck, MagicCardRequest card, int quantity) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Group By (Type/CMC) and Sort By (Name/CMC) controls above the card grid for customizable deck views.
  * Cards can be grouped by mana value or by card type.

* **Bug Fixes**
  * Improved card image/hover stability and ensured downloaded deck filename reflects the displayed commander.
  * Missing deck now shows an error message instead of a blank page.

* **Other**
  * Deck list spacing adjusted.
  * Database service no longer exposes the host port.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->